### PR TITLE
Add download route for log file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This project provides a simple Express server with an interface to OpenAI. The
 server now includes a middleware that records incoming user information such as
 IP address and approximate location. Each request creates a JSON entry appended
-to `user_log.json`.
+to `user_log.json`. You can download the accumulated log file by visiting
+`/download-log`.
 
 Run the server with `npm start`.

--- a/server.js
+++ b/server.js
@@ -39,6 +39,11 @@ app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 
+// Route to download the user log
+app.get('/download-log', (req, res) => {
+  res.download(path.join(__dirname, 'user_log.json'));
+});
+
 // API endpoint
 app.post('/api/openai', async (req, res) => {
   const { prompt } = req.body;


### PR DESCRIPTION
## Summary
- make `user_log.json` downloadable via `/download-log`
- document new log download endpoint

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_685f3ec7ef04832ca796c23bfa91ff9f