### PR TITLE
Return OpenAI raw data and log DB inserts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -230,12 +230,39 @@
 
         const data = await response.json();
         if (type === 'rate') {
-          document.getElementById('result').innerHTML = 
-            '<table><tr><th>Criteria</th><th>Rating</th><th>Comments</th></tr>' + 
-            data.result + 
+          document.getElementById('result').innerHTML =
+            '<table><tr><th>Criteria</th><th>Rating</th><th>Comments</th></tr>' +
+            data.result +
             '</table>';
         } else {
           document.getElementById('result').innerText = data.result;
+        }
+
+        const payload = {
+          action: type === 'rate' ? 'RATE' : 'REWRITE',
+          original_story: userStory,
+          original_criteria: acceptanceCriteria,
+          raw_response: data.raw
+        };
+
+        if (type === 'rate') {
+          payload.ratings = data.result;
+        } else {
+          payload.rewritten_story = data.result;
+        }
+
+        try {
+          const insertResp = await fetch('/user-story', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+          });
+          if (!insertResp.ok) {
+            const errorText = await insertResp.text();
+            console.error('Insert error:', errorText);
+          }
+        } catch (err) {
+          console.error('Insert error:', err);
         }
       } catch (error) {
         console.error('Error response:', error);

--- a/server.js
+++ b/server.js
@@ -69,7 +69,10 @@ app.post('/api/openai', async (req, res) => {
       model: 'gpt-4',
       messages: [{ role: 'user', content: prompt }],
     });
-    res.json({ result: chat.choices[0].message.content });
+    res.json({
+      result: chat.choices[0].message.content,
+      raw: chat
+    });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }


### PR DESCRIPTION
## Summary
- return the full raw response from OpenAI in `/api/openai`
- store results by posting `RATE` or `REWRITE` data to `/user-story`
- log any insertion errors to console

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685ff6852084832c936d98f20c90b7d1