### PR TITLE
Handle failed pool connect

### DIFF
--- a/server.js
+++ b/server.js
@@ -128,7 +128,13 @@ app.post('/user-story', async (req, res) => {
     return res.status(400).json({ error: 'Missing required fields' });
   }
 
-  const client = await pool.connect();
+  let client;
+  try {
+    client = await pool.connect();
+  } catch (err) {
+    console.error('Database connection failed', err);
+    return res.status(500).json({ error: 'Database connection failed' });
+  }
   try {
     await client.query('BEGIN');
     const userStoryInsert = await client.query(


### PR DESCRIPTION
## Summary
- log database connection failures in the `/user-story` route
- respond with a 500 status on connection failure

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ffb696e9c832c835118c6d2d7662b