### PR TITLE
Add env var docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,20 @@ IP address and approximate location. Each request creates a JSON entry appended
 to `user_log.json`. You can download the accumulated log file by visiting
 `/download-log`.
 
-Run the server with `npm start`.
+## Configuration
+
+Set a few environment variables before starting the server:
+
+- `DATABASE_URL` - PostgreSQL connection string. When the app runs in a
+  container, use the internal service URL (e.g. `postgres://user:pass@db:5432/dbname`).
+  Outside of a container, supply the external host address instead.
+- `OPENAI_API_KEY` - OpenAI API key used for all AI interactions.
+- `APP_ENV` - Optional. Defaults to `PROD`. Chooses between production tables
+  (`user_stories` / `ai_responses`) and test tables (`tt_user_stories` /
+  `tt_ai_responses`).
+
+Add these variables to a `.env` file or export them in your shell, then start
+the server with `npm start`.
 
 ## API Endpoints
 


### PR DESCRIPTION
## Summary
- document environment variables in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ffb670b1c832c98237ee2c979cc28