### PR TITLE
Add schema docs and migration for test table

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,17 @@ Use the `APP_ENV` environment variable to route inserts:
 
 - `APP_ENV=PROD` (default) &rarr; tables `user_stories` and `ai_responses`.
 - `APP_ENV=TEST` &rarr; tables `tt_user_stories` and `tt_ai_responses`.
+
+## Database Schema
+
+The SQL definitions for all tables are located in [docs/schema.sql](docs/schema.sql). These statements can be used to reproduce the required database structure.
+
+### Updating existing test tables
+
+Older deployments of `tt_ai_responses` may be missing the `action` column. Apply the migration in `docs/migrations/tt_ai_responses_add_action.sql` or run the following SQL manually:
+
+```sql
+ALTER TABLE tt_ai_responses ADD COLUMN action VARCHAR(20) NOT NULL;
+```
+
+Without this column, `/user-story` requests will fail with a *column "action" does not exist* error.

--- a/docs/migrations/tt_ai_responses_add_action.sql
+++ b/docs/migrations/tt_ai_responses_add_action.sql
@@ -1,0 +1,3 @@
+-- Adds missing 'action' column to the test responses table
+ALTER TABLE tt_ai_responses
+  ADD COLUMN action VARCHAR(20) NOT NULL;

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -1,0 +1,47 @@
+-- Schema for StoryRefiner database tables
+
+-- Production tables
+CREATE TABLE IF NOT EXISTS user_stories (
+    id SERIAL PRIMARY KEY,
+    original_story TEXT NOT NULL,
+    original_criteria TEXT,
+    country TEXT,
+    state TEXT,
+    city TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS ai_responses (
+    id SERIAL PRIMARY KEY,
+    user_story_id INTEGER REFERENCES user_stories(id) ON DELETE CASCADE,
+    action VARCHAR(20) NOT NULL,
+    ratings JSONB,
+    rewritten_story TEXT,
+    rewritten_assumptions TEXT,
+    rewritten_criteria TEXT,
+    raw_response JSONB,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Test tables mirror the production structure
+CREATE TABLE IF NOT EXISTS tt_user_stories (
+    id SERIAL PRIMARY KEY,
+    original_story TEXT NOT NULL,
+    original_criteria TEXT,
+    country TEXT,
+    state TEXT,
+    city TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS tt_ai_responses (
+    id SERIAL PRIMARY KEY,
+    user_story_id INTEGER REFERENCES tt_user_stories(id) ON DELETE CASCADE,
+    action VARCHAR(20) NOT NULL,
+    ratings JSONB,
+    rewritten_story TEXT,
+    rewritten_assumptions TEXT,
+    rewritten_criteria TEXT,
+    raw_response JSONB,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary
- document database schema in `docs/schema.sql`
- add migration for adding `action` column to `tt_ai_responses`
- update README with schema info and instructions to apply the migration

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685ffd4fbef0832caa733539e93bc9ec