### PR TITLE
Add Azure DevOps extension example

### DIFF
--- a/devops-extension/README.md
+++ b/devops-extension/README.md
@@ -1,0 +1,21 @@
+# Story Quality AI Azure DevOps Extension
+
+This folder contains a minimal example of an Azure DevOps extension that adds a **Story Quality (AI)** section to the User Story work item form. The section displays two buttons, **Rate It** and **Re-write**, which call the existing API provided by this repository.
+
+## Files
+
+- `vss-extension.json` – extension manifest
+- `index.html` – iframe content loaded in the work item form
+- `index.js` – logic that retrieves work item fields and calls the API
+- `style.css` – basic styling for the iframe
+
+## Usage
+
+1. Update `SERVER_URL` in `index.js` to point to a running instance of this server.
+2. Install the [Azure DevOps extension CLI](https://learn.microsoft.com/azure/devops/extend/develop/command-line?view=azure-devops) and package the extension:
+   ```bash
+   tfx extension create --manifest-globs vss-extension.json
+   ```
+3. Upload the generated `.vsix` to your Azure DevOps organization and install it.
+
+The extension will appear only for work items of type **User Story** and will display the AI results inside the **Story Quality (AI)** group.

--- a/devops-extension/index.html
+++ b/devops-extension/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <link rel="stylesheet" href="style.css" />
+  <script src="https://unpkg.com/@microsoft/azure-devops-extension-sdk"></script>
+</head>
+<body>
+  <div id="container">
+    <button id="rateBtn">Rate It</button>
+    <button id="rewriteBtn">Re-write</button>
+    <div id="loader" style="display:none;">Loading...</div>
+    <pre id="result"></pre>
+  </div>
+  <script src="index.js"></script>
+</body>
+</html>

--- a/devops-extension/index.js
+++ b/devops-extension/index.js
@@ -1,0 +1,39 @@
+var SERVER_URL = ""; // e.g. https://myserver.example.com
+
+SDK.init();
+SDK.ready().then(function() {
+  document.getElementById("rateBtn").addEventListener("click", function() {
+    handleAction("rate");
+  });
+  document.getElementById("rewriteBtn").addEventListener("click", function() {
+    handleAction("rewrite");
+  });
+});
+
+async function handleAction(type) {
+  document.getElementById("loader").style.display = "block";
+  var formService = await SDK.getService("ms.vss-work-web.work-item-form");
+  var title = await formService.getFieldValue("System.Title");
+  var description = await formService.getFieldValue("System.Description");
+
+  var prompt;
+  if (type === "rate") {
+    prompt = `Please rate the following user story based on clarity, feasibility, testability, completeness and value. Return HTML <tr> rows only.\nTitle: ${title}\nDescription: ${description}`;
+  } else {
+    prompt = `Please rewrite the user story.\nTitle: ${title}\nDescription: ${description}`;
+  }
+
+  try {
+    var response = await fetch(SERVER_URL + "/api/openai", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: prompt })
+    });
+    var data = await response.json();
+    document.getElementById("result").textContent = data.result;
+  } catch (err) {
+    document.getElementById("result").textContent = "Error: " + err.message;
+  } finally {
+    document.getElementById("loader").style.display = "none";
+  }
+}

--- a/devops-extension/style.css
+++ b/devops-extension/style.css
@@ -1,0 +1,7 @@
+#container {
+  font-family: 'Segoe UI', sans-serif;
+}
+#result {
+  white-space: pre-wrap;
+  margin-top: 10px;
+}

--- a/devops-extension/vss-extension.json
+++ b/devops-extension/vss-extension.json
@@ -1,0 +1,39 @@
+{
+  "manifestVersion": 1,
+  "id": "story-quality-ai-extension",
+  "name": "Story Quality AI",
+  "version": "1.0.0",
+  "publisher": "sample",
+  "description": "Rate or rewrite user stories using OpenAI.",
+  "targets": [
+    "Microsoft.VisualStudio.Services"
+  ],
+  "files": [
+    { "path": "index.html", "address": "index.html" },
+    { "path": "index.js", "address": "index.js" },
+    { "path": "style.css", "address": "style.css" }
+  ],
+  "contributions": [
+    {
+      "id": "story-quality-group",
+      "type": "ms.vss-work-web.work-item-form-group",
+      "targets": [ "ms.vss-work-web.work-item-form" ],
+      "properties": {
+        "name": "Story Quality (AI)",
+        "controls": [
+          {
+            "id": "story-quality-control",
+            "type": "ms.vss-web.control-extension",
+            "properties": {
+              "uri": "index.html",
+              "height": 200
+            }
+          }
+        ]
+      },
+      "constraints": {
+        "workItemType": "User Story"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `devops-extension` folder with a sample Azure DevOps extension
- include manifest, minimal HTML/JS/CSS and documentation on how to build

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68616bf0d144832c97d3707b2f0b5ce0