### PR TITLE
Improve Azure DevOps extension handling

### DIFF
--- a/devops-extension/index.js
+++ b/devops-extension/index.js
@@ -29,8 +29,11 @@ async function handleAction(type) {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ prompt: prompt })
     });
+    if (!response.ok) {
+      throw new Error("Request failed with status " + response.status);
+    }
     var data = await response.json();
-    document.getElementById("result").textContent = data.result;
+    document.getElementById("result").innerHTML = data.result;
   } catch (err) {
     document.getElementById("result").textContent = "Error: " + err.message;
   } finally {


### PR DESCRIPTION
## Summary
- improve error handling in Azure DevOps extension
- support rendering HTML returned from API

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861980d1e04832cb68cb9cde4a998e5