### PR TITLE
Add unique locations endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 This project provides a simple Express server with an interface to OpenAI. The
 server now includes middleware that records the caller's approximate location, but it does **not** store the originating IP address. Each request creates a JSON entry appended
 to `user_log.json`. You can download the accumulated log file by visiting
-`/download-log`.
+`/download-log`. A separate endpoint `/unique-locations` reports how many
+distinct `(country, state, city)` combinations appear in the log file.
 
 ## Configuration
 
@@ -29,6 +30,8 @@ the server with `npm start`.
   is reachable.
 - `POST /seed-test` - Inserts a row into the table selected by `APP_ENV` using
   values from the request body and the caller's detected location.
+- `GET /unique-locations` - Returns the number of distinct `(country, state,
+  city)` combinations found in `user_log.json`.
 
 ### Environment Based Tables
 


### PR DESCRIPTION
## Summary
- add `/unique-locations` route to count distinct `(country, state, city)` tuples
- document the new endpoint in README

## Testing
- `node --check server.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68642f079aa8832cbcf6dd45dc990746