### PR TITLE
Include test approach in rewrite prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Set a few environment variables before starting the server:
 Add these variables to a `.env` file or export them in your shell, then start
 the server with `npm start`.
 
+The web UI offers two AI-powered actions:
+
+- **Rate It** &ndash; scores the user story against multiple criteria.
+- **Re-write** &ndash; rewrites the story, lists assumptions and acceptance
+  criteria, and now includes a short test approach tailored to the story.
+
 ## API Endpoints
 
 - `POST /user-story` - Persist a user story and associated AI data. The payload

--- a/devops-extension/README.md
+++ b/devops-extension/README.md
@@ -1,6 +1,6 @@
 # Story Quality AI Azure DevOps Extension
 
-This folder contains a minimal example of an Azure DevOps extension that adds a **Story Quality (AI)** section to the User Story work item form. The section displays two buttons, **Rate It** and **Re-write**, which call the existing API provided by this repository.
+This folder contains a minimal example of an Azure DevOps extension that adds a **Story Quality (AI)** section to the User Story work item form. The section displays two buttons, **Rate It** and **Re-write**, which call the existing API provided by this repository. The re-write action now includes a brief test approach alongside the rewritten story.
 
 ## Files
 

--- a/devops-extension/index.js
+++ b/devops-extension/index.js
@@ -20,7 +20,7 @@ async function handleAction(type) {
   if (type === "rate") {
     prompt = `Please rate the following user story based on clarity, feasibility, testability, completeness and value. Return HTML <tr> rows only.\nTitle: ${title}\nDescription: ${description}`;
   } else {
-    prompt = `Please rewrite the user story.\nTitle: ${title}\nDescription: ${description}`;
+    prompt = `Please rewrite the user story and provide a short test approach that matches it.\nTitle: ${title}\nDescription: ${description}`;
   }
 
   try {

--- a/public/index.html
+++ b/public/index.html
@@ -213,7 +213,7 @@
       if (type === 'rate') {
         prompt = `Please rate the following user story based on the following criteria:\n\n- Clarity\n- Feasibility\n- Testability\n- Completeness\n- Value\n\nReturn the results as HTML <tr> rows only, like this:\n<tr><td>Clarity</td><td>8/10</td><td>Clear but missing outcome detail</td></tr>\n...\n\nUser Story: ${userStory}\nAcceptance Criteria: ${acceptanceCriteria}`;
       } else {
-        prompt = `Please rewrite the following user story in proper format.\n\n1. Use the format: 'As a [user], I want to [goal] so that [reason]'.\n2. List assumptions clearly.\n3. Provide well-defined, bullet-point acceptance criteria.\n\nUser Story: ${userStory}\nAcceptance Criteria: ${acceptanceCriteria}`;
+        prompt = `Please rewrite the following user story in proper format.\n\n1. Use the format: 'As a [user], I want to [goal] so that [reason]'.\n2. List assumptions clearly.\n3. Provide well-defined, bullet-point acceptance criteria.\n4. Describe a brief test approach that covers the user story.\n\nUser Story: ${userStory}\nAcceptance Criteria: ${acceptanceCriteria}`;
       }
 
       try {


### PR DESCRIPTION
## Summary
- clarify that the rewrite feature returns a short test approach in README docs
- mention same capability in Azure DevOps extension docs
- update rewrite prompts in web UI and extension to request a test approach

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6866b2fdb0dc832cb3efae7c58d29afc