### PR TITLE
Add summary action

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,17 @@ Set a few environment variables before starting the server:
 Add these variables to a `.env` file or export them in your shell, then start
 the server with `npm start`.
 
-The web UI offers two AI-powered actions:
+The web UI offers three AI-powered actions:
 
 - **Rate It** &ndash; scores the user story against multiple criteria.
 - **Re-write** &ndash; rewrites the story, lists assumptions and acceptance
   criteria, and now includes a short test approach tailored to the story.
+- **Summary** &ndash; generates a concise table of suggested test cases.
 
 ## API Endpoints
 
 - `POST /user-story` - Persist a user story and associated AI data. The payload
-  varies based on the `action` (`RATE` or `REWRITE`) and always includes
+  varies based on the `action` (`RATE`, `REWRITE` or `SUMMARY`) and always includes
   `raw_response` from ChatGPT.
 - `GET /health` - Database connectivity check. Returns `200` when the database
   is reachable.

--- a/devops-extension/README.md
+++ b/devops-extension/README.md
@@ -1,6 +1,6 @@
 # Story Quality AI Azure DevOps Extension
 
-This folder contains a minimal example of an Azure DevOps extension that adds a **Story Quality (AI)** section to the User Story work item form. The section displays two buttons, **Rate It** and **Re-write**, which call the existing API provided by this repository. The re-write action now includes a brief test approach alongside the rewritten story.
+This folder contains a minimal example of an Azure DevOps extension that adds a **Story Quality (AI)** section to the User Story work item form. The section displays three buttons, **Rate It**, **Re-write**, and **Summary**, which call the existing API provided by this repository. The re-write action now includes a brief test approach alongside the rewritten story, and the summary option returns a table of suggested tests.
 
 ## Files
 

--- a/devops-extension/index.html
+++ b/devops-extension/index.html
@@ -9,6 +9,7 @@
   <div id="container">
     <button id="rateBtn">Rate It</button>
     <button id="rewriteBtn">Re-write</button>
+    <button id="summaryBtn">Summary</button>
     <div id="loader" style="display:none;">Loading...</div>
     <pre id="result"></pre>
   </div>

--- a/devops-extension/index.js
+++ b/devops-extension/index.js
@@ -8,6 +8,9 @@ SDK.ready().then(function() {
   document.getElementById("rewriteBtn").addEventListener("click", function() {
     handleAction("rewrite");
   });
+  document.getElementById("summaryBtn").addEventListener("click", function() {
+    handleAction("summary");
+  });
 });
 
 async function handleAction(type) {
@@ -19,8 +22,10 @@ async function handleAction(type) {
   var prompt;
   if (type === "rate") {
     prompt = `Please rate the following user story based on clarity, feasibility, testability, completeness and value. Return HTML <tr> rows only.\nTitle: ${title}\nDescription: ${description}`;
-  } else {
+  } else if (type === "rewrite") {
     prompt = `Please rewrite the user story and provide a short test approach that matches it.\nTitle: ${title}\nDescription: ${description}`;
+  } else {
+    prompt = `Summarize recommended test cases in a table with columns ID, Test Description and Risk Level. Return only HTML <tr> rows.\nTitle: ${title}\nDescription: ${description}`;
   }
 
   try {

--- a/public/index.html
+++ b/public/index.html
@@ -181,6 +181,7 @@
     <textarea id="acceptanceCriteria" rows="4" placeholder="Enter Acceptance Criteria"></textarea>
     <button onclick="callOpenAI('rate')">Rate It</button>
     <button onclick="callOpenAI('rewrite')">Re-write</button>
+    <button onclick="callOpenAI('summary')">Summary</button>
     <div id="loader" style="display:none;" class="spinner"></div>
     <div id="result"></div>
   </div>
@@ -212,8 +213,10 @@
       let prompt = '';
       if (type === 'rate') {
         prompt = `Please rate the following user story based on the following criteria:\n\n- Clarity\n- Feasibility\n- Testability\n- Completeness\n- Value\n\nReturn the results as HTML <tr> rows only, like this:\n<tr><td>Clarity</td><td>8/10</td><td>Clear but missing outcome detail</td></tr>\n...\n\nUser Story: ${userStory}\nAcceptance Criteria: ${acceptanceCriteria}`;
-      } else {
+      } else if (type === 'rewrite') {
         prompt = `Please rewrite the following user story in proper format.\n\n1. Use the format: 'As a [user], I want to [goal] so that [reason]'.\n2. List assumptions clearly.\n3. Provide well-defined, bullet-point acceptance criteria.\n4. Describe a brief test approach that covers the user story.\n\nUser Story: ${userStory}\nAcceptance Criteria: ${acceptanceCriteria}`;
+      } else {
+        prompt = `Summarize recommended test cases for the following user story. Provide a table using the columns ID, Test Description and Risk Level. Return only HTML <tr> rows.\n\nUser Story: ${userStory}\nAcceptance Criteria: ${acceptanceCriteria}`;
       }
 
       try {
@@ -234,12 +237,18 @@
             '<table><tr><th>Criteria</th><th>Rating</th><th>Comments</th></tr>' +
             data.result +
             '</table>';
-        } else {
+        } else if (type === 'rewrite') {
           document.getElementById('result').innerText = data.result;
+        } else {
+          document.getElementById('result').innerHTML =
+            '<table><tr><th>ID</th><th>Test Description</th><th>Risk Level</th></tr>' +
+            data.result +
+            '</table>';
         }
 
         const payload = {
-          action: type === 'rate' ? 'RATE' : 'REWRITE',
+          action:
+            type === 'rate' ? 'RATE' : type === 'rewrite' ? 'REWRITE' : 'SUMMARY',
           original_story: userStory,
           original_criteria: acceptanceCriteria,
           raw_response: data.raw
@@ -247,6 +256,8 @@
 
         if (type === 'rate') {
           payload.ratings = data.result;
+        } else if (type === 'rewrite') {
+          payload.rewritten_story = data.result;
         } else {
           payload.rewritten_story = data.result;
         }


### PR DESCRIPTION
## Summary
- add Summary option in the web UI and DevOps extension
- expand `callOpenAI` to craft a test-summary prompt and send `SUMMARY` action
- render returned HTML table
- document new action in READMEs

## Testing
- `node --check devops-extension/index.js`

------
https://chatgpt.com/codex/tasks/task_e_68724ba6ab08832c95c0c05ec275e6c0