### PR TITLE
Rename Summary button

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The web UI offers three AI-powered actions:
 - **Rate It** &ndash; scores the user story against multiple criteria.
 - **Re-write** &ndash; rewrites the story, lists assumptions and acceptance
   criteria, and now includes a short test approach tailored to the story.
-- **Summary** &ndash; generates a concise table of suggested test cases.
+- **Test Summary** &ndash; generates a concise table of suggested test cases.
 
 ## API Endpoints
 

--- a/devops-extension/README.md
+++ b/devops-extension/README.md
@@ -1,6 +1,6 @@
 # Story Quality AI Azure DevOps Extension
 
-This folder contains a minimal example of an Azure DevOps extension that adds a **Story Quality (AI)** section to the User Story work item form. The section displays three buttons, **Rate It**, **Re-write**, and **Summary**, which call the existing API provided by this repository. The re-write action now includes a brief test approach alongside the rewritten story, and the summary option returns a table of suggested tests.
+This folder contains a minimal example of an Azure DevOps extension that adds a **Story Quality (AI)** section to the User Story work item form. The section displays three buttons, **Rate It**, **Re-write**, and **Test Summary**, which call the existing API provided by this repository. The re-write action now includes a brief test approach alongside the rewritten story, and the summary option returns a table of suggested tests.
 
 ## Files
 

--- a/devops-extension/index.html
+++ b/devops-extension/index.html
@@ -9,7 +9,7 @@
   <div id="container">
     <button id="rateBtn">Rate It</button>
     <button id="rewriteBtn">Re-write</button>
-    <button id="summaryBtn">Summary</button>
+    <button id="summaryBtn">Test Summary</button>
     <div id="loader" style="display:none;">Loading...</div>
     <pre id="result"></pre>
   </div>

--- a/public/index.html
+++ b/public/index.html
@@ -181,7 +181,7 @@
     <textarea id="acceptanceCriteria" rows="4" placeholder="Enter Acceptance Criteria"></textarea>
     <button onclick="callOpenAI('rate')">Rate It</button>
     <button onclick="callOpenAI('rewrite')">Re-write</button>
-    <button onclick="callOpenAI('summary')">Summary</button>
+    <button onclick="callOpenAI('summary')">Test Summary</button>
     <div id="loader" style="display:none;" class="spinner"></div>
     <div id="result"></div>
   </div>


### PR DESCRIPTION
## Summary
- rename Summary button to Test Summary in web UI
- rename Summary button to Test Summary in DevOps extension
- update docs to refer to Test Summary

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68724f8a3d28832c8f7863486ca03036