### PR TITLE
Add Generate Test Scripts feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,18 @@ Set a few environment variables before starting the server:
 Add these variables to a `.env` file or export them in your shell, then start
 the server with `npm start`.
 
-The web UI offers three AI-powered actions:
+The web UI offers four AI-powered actions:
 
 - **Rate It** &ndash; scores the user story against multiple criteria.
 - **Re-write** &ndash; rewrites the story, lists assumptions and acceptance
   criteria, and now includes a short test approach tailored to the story.
 - **Test & Risk Summary** &ndash; generates a concise table of suggested test cases.
+- **Generate Test Scripts** &ndash; produces detailed test scripts that can be exported to Excel.
 
 ## API Endpoints
 
 - `POST /user-story` - Persist a user story and associated AI data. The payload
-  varies based on the `action` (`RATE`, `REWRITE` or `SUMMARY`) and always includes
+  varies based on the `action` (`RATE`, `REWRITE`, `SUMMARY` or `SCRIPTS`) and always includes
   `raw_response` from ChatGPT.
 - `GET /health` - Database connectivity check. Returns `200` when the database
   is reachable.

--- a/devops-extension/index.html
+++ b/devops-extension/index.html
@@ -10,6 +10,8 @@
     <button id="rateBtn">Rate It</button>
     <button id="rewriteBtn">Re-write</button>
     <button id="summaryBtn">Test &amp; Risk Summary</button>
+    <button id="scriptsBtn">Generate Test Scripts</button>
+    <button id="exportBtn" style="display:none;">Export to CSV</button>
     <div id="loader" style="display:none;">Loading...</div>
     <pre id="result"></pre>
   </div>

--- a/devops-extension/index.js
+++ b/devops-extension/index.js
@@ -11,6 +11,12 @@ SDK.ready().then(function() {
   document.getElementById("summaryBtn").addEventListener("click", function() {
     handleAction("summary");
   });
+  document.getElementById("scriptsBtn").addEventListener("click", function() {
+    handleAction("scripts");
+  });
+  document.getElementById("exportBtn").addEventListener("click", function() {
+    exportToCsv();
+  });
 });
 
 async function handleAction(type) {
@@ -24,6 +30,8 @@ async function handleAction(type) {
     prompt = `Please rate the following user story based on clarity, feasibility, testability, completeness and value. Return HTML <tr> rows only.\nTitle: ${title}\nDescription: ${description}`;
   } else if (type === "rewrite") {
     prompt = `Please rewrite the user story and provide a short test approach that matches it.\nTitle: ${title}\nDescription: ${description}`;
+  } else if (type === "scripts") {
+    prompt = `Analyze the user story and identify all test scenarios including positive, negative and edge cases. Provide a table with columns Scenario Title, Action and Expected Result and return only HTML <tr> rows, repeating the scenario title for each step.\nTitle: ${title}\nDescription: ${description}`;
   } else {
     prompt = `Summarize recommended test cases in a table with columns ID, Test Description and Risk Level. Return only HTML <tr> rows.\nTitle: ${title}\nDescription: ${description}`;
   }
@@ -39,9 +47,36 @@ async function handleAction(type) {
     }
     var data = await response.json();
     document.getElementById("result").innerHTML = data.result;
+    if (type === "scripts") {
+      document.getElementById("exportBtn").style.display = "block";
+    } else {
+      document.getElementById("exportBtn").style.display = "none";
+    }
   } catch (err) {
     document.getElementById("result").textContent = "Error: " + err.message;
   } finally {
     document.getElementById("loader").style.display = "none";
   }
+}
+
+function exportToCsv() {
+  var table = document.querySelector("#result table");
+  if (!table) return;
+  var rows = Array.from(table.querySelectorAll("tr"));
+  var csv = rows
+    .map(function(row) {
+      return Array.from(row.querySelectorAll("th,td"))
+        .map(function(cell) {
+          return '"' + cell.innerText.replace(/"/g, '""') + '"';
+        })
+        .join(",");
+    })
+    .join("\n");
+  var blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  var link = document.createElement("a");
+  link.href = URL.createObjectURL(blob);
+  link.download = "test-scripts.csv";
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
 }

--- a/public/index.html
+++ b/public/index.html
@@ -197,6 +197,8 @@
     <button onclick="callOpenAI('rate')">Rate It</button>
     <button onclick="callOpenAI('rewrite')">Re-write</button>
     <button onclick="callOpenAI('summary')">Test &amp; Risk Summary</button>
+    <button onclick="callOpenAI('scripts')">Generate Test Scripts</button>
+    <button id="exportBtn" onclick="exportToExcel()" style="display:none;">Export to Excel</button>
     <div id="loader" style="display:none;" class="spinner"><span id="timer">0</span></div>
     <div id="result"></div>
   </div>
@@ -242,6 +244,8 @@
         prompt = `Please rate the following user story based on the following criteria:\n\n- Clarity\n- Feasibility\n- Testability\n- Completeness\n- Value\n\nReturn the results as HTML <tr> rows only, like this:\n<tr><td>Clarity</td><td>8/10</td><td>Clear but missing outcome detail</td></tr>\n...\n\nUser Story: ${userStory}\nAssumptions: ${assumptions}\nAcceptance Criteria: ${acceptanceCriteria}`;
       } else if (type === 'rewrite') {
         prompt = `Please rewrite the following user story in proper format.\n\n1. Use the format: 'As a [user], I want to [goal] so that [reason]'.\n2. List assumptions clearly.\n3. Provide well-defined, bullet-point acceptance criteria.\n4. Describe a brief test approach that covers the user story.\n\nUser Story: ${userStory}\nAssumptions: ${assumptions}\nAcceptance Criteria: ${acceptanceCriteria}`;
+      } else if (type === 'scripts') {
+        prompt = `Analyze the User Story, Assumptions and Acceptance Criteria. List every test scenario including positive, negative and edge cases. For each scenario, provide numbered test steps with an action and expected result. Return only HTML <tr> rows using columns Scenario Title, Action, Expected Result, repeating the scenario title for each step.\n\nUser Story: ${userStory}\nAssumptions: ${assumptions}\nAcceptance Criteria: ${acceptanceCriteria}`;
       } else {
         prompt = `Summarize recommended test cases for the following user story. Provide a table using the columns ID, Test Description and Risk Level. Return only HTML <tr> rows.\n\nUser Story: ${userStory}\nAssumptions: ${assumptions}\nAcceptance Criteria: ${acceptanceCriteria}`;
       }
@@ -264,18 +268,33 @@
             '<table><tr><th>Criteria</th><th>Rating</th><th>Comments</th></tr>' +
             data.result +
             '</table>';
+          document.getElementById('exportBtn').style.display = 'none';
         } else if (type === 'rewrite') {
           document.getElementById('result').innerText = data.result;
+          document.getElementById('exportBtn').style.display = 'none';
+        } else if (type === 'scripts') {
+          document.getElementById('result').innerHTML =
+            '<table><tr><th>Scenario Title</th><th>Action</th><th>Expected Result</th></tr>' +
+            data.result +
+            '</table>';
+          document.getElementById('exportBtn').style.display = 'inline-block';
         } else {
           document.getElementById('result').innerHTML =
             '<table><tr><th>ID</th><th>Test Description</th><th>Risk Level</th></tr>' +
             data.result +
             '</table>';
+          document.getElementById('exportBtn').style.display = 'none';
         }
 
         const payload = {
           action:
-            type === 'rate' ? 'RATE' : type === 'rewrite' ? 'REWRITE' : 'SUMMARY',
+            type === 'rate'
+              ? 'RATE'
+              : type === 'rewrite'
+              ? 'REWRITE'
+              : type === 'scripts'
+              ? 'SCRIPTS'
+              : 'SUMMARY',
           original_story: userStory,
           original_assumptions: assumptions,
           original_criteria: acceptanceCriteria,
@@ -284,8 +303,6 @@
 
         if (type === 'rate') {
           payload.ratings = data.result;
-        } else if (type === 'rewrite') {
-          payload.rewritten_story = data.result;
         } else {
           payload.rewritten_story = data.result;
         }
@@ -311,6 +328,26 @@
         clearInterval(timerId);
         document.getElementById('timer').textContent = '0';
       }
+    }
+
+    function exportToExcel() {
+      const table = document.querySelector('#result table');
+      if (!table) return;
+      const rows = Array.from(table.querySelectorAll('tr'));
+      const csv = rows
+        .map(row =>
+          Array.from(row.querySelectorAll('th,td'))
+            .map(col => '"' + col.innerText.replace(/"/g, '""') + '"')
+            .join(',')
+        )
+        .join('\n');
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = 'test-scripts.csv';
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add `Generate Test Scripts` button to main UI with export capability
- support new `scripts` action in `callOpenAI` logic
- include export-to-CSV function for generated scripts
- extend Azure DevOps extension with new button and CSV export
- document new feature in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6873c588f264832c92dae38ea3a80b74