### PR TITLE
Add Generate Test Scripts button

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ The web UI offers four AI-powered actions:
   criteria, and now includes a short test approach tailored to the story.
 - **Test & Risk Summary** &ndash; generates a concise table of suggested test cases.
 - **Generate Test Scripts** &ndash; produces detailed test scripts that can be exported to Excel.
+  Use the "Generate Test Scripts" button to run an advanced prompt that returns
+  step-by-step test cases in JSON format, automatically rendered as a table with
+  an option to export the results to Excel.
 
 ## API Endpoints
 

--- a/public/index.html
+++ b/public/index.html
@@ -197,6 +197,8 @@
     <button onclick="callOpenAI('rate')">Rate It</button>
     <button onclick="callOpenAI('rewrite')">Re-write</button>
     <button onclick="callOpenAI('summary')">Test &amp; Risk Summary</button>
+    <button onclick="callOpenAI('scripts')" id="scriptsBtn">Generate Test Scripts</button>
+    <button id="exportBtn" style="display:none;" onclick="exportToCsv()">Export to Excel</button>
     <div id="loader" style="display:none;" class="spinner"><span id="timer">0</span></div>
     <div id="result"></div>
   </div>
@@ -242,6 +244,8 @@
         prompt = `Please rate the following user story based on the following criteria:\n\n- Clarity\n- Feasibility\n- Testability\n- Completeness\n- Value\n\nReturn the results as HTML <tr> rows only, like this:\n<tr><td>Clarity</td><td>8/10</td><td>Clear but missing outcome detail</td></tr>\n...\n\nUser Story: ${userStory}\nAssumptions: ${assumptions}\nAcceptance Criteria: ${acceptanceCriteria}`;
       } else if (type === 'rewrite') {
         prompt = `Please rewrite the following user story in proper format.\n\n1. Use the format: 'As a [user], I want to [goal] so that [reason]'.\n2. List assumptions clearly.\n3. Provide well-defined, bullet-point acceptance criteria.\n4. Describe a brief test approach that covers the user story.\n\nUser Story: ${userStory}\nAssumptions: ${assumptions}\nAcceptance Criteria: ${acceptanceCriteria}`;
+      } else if (type === 'scripts') {
+        prompt = `You are a senior test analyst. Be extremely thorough and analytical.\n\nUse the following inputs provided by the user:\n\nUser Story:\n${userStory}\n\nAssumptions:\n${assumptions}\n\nAcceptance Criteria:\n${acceptanceCriteria}\n\nYour tasks:\n\n1. Carefully analyze this information and identify all possible test cases, including positive, negative, edge, and alternate scenarios that a senior QA would consider. Ensure no relevant scenario is missed.\n\n2. For each test case, generate all the detailed test steps needed to fully validate the scenario. Each test case must have its step numbering start at 1.\n\n3. Return the data as a structured JSON array of rows, where each row represents a single test step. Each row must include these exact fields:\n- id: leave this blank (Azure DevOps assigns it automatically)\n- work_item_type: always set to "Test Case"\n- title: the test case title (repeated on every row of that test case)\n- test_step: the step number, starting from 1 for each new test case\n- step_action: what the user does\n- step_expected: what is expected to happen\n\nImportant formatting requirements:\n- Each new test case must restart its test_step at 1.\n- Repeat the fields id, work_item_type, and title for every step of the same test case, as Azure DevOps needs this to group the steps under each test case.\n- Ensure every assumption and acceptance criterion is fully tested, and include any implied scenarios a professional senior QA would identify.\n\nOutput only the JSON array of rows, with no extra commentary or explanation. Format it cleanly for easy parsing.`;
       } else {
         prompt = `Summarize recommended test cases for the following user story. Provide a table using the columns ID, Test Description and Risk Level. Return only HTML <tr> rows.\n\nUser Story: ${userStory}\nAssumptions: ${assumptions}\nAcceptance Criteria: ${acceptanceCriteria}`;
       }
@@ -264,18 +268,36 @@
             '<table><tr><th>Criteria</th><th>Rating</th><th>Comments</th></tr>' +
             data.result +
             '</table>';
+          document.getElementById('exportBtn').style.display = 'none';
         } else if (type === 'rewrite') {
           document.getElementById('result').innerText = data.result;
+          document.getElementById('exportBtn').style.display = 'none';
+        } else if (type === 'scripts') {
+          const rows = JSON.parse(data.result);
+          let html = '<table><tr><th>ID</th><th>Work Item Type</th><th>Title</th><th>Step #</th><th>Action</th><th>Expected</th></tr>';
+          rows.forEach(r => {
+            html += `<tr><td>${r.id}</td><td>${r.work_item_type}</td><td>${r.title}</td><td>${r.test_step}</td><td>${r.step_action}</td><td>${r.step_expected}</td></tr>`;
+          });
+          html += '</table>';
+          document.getElementById('result').innerHTML = html;
+          document.getElementById('exportBtn').style.display = 'inline-block';
         } else {
           document.getElementById('result').innerHTML =
             '<table><tr><th>ID</th><th>Test Description</th><th>Risk Level</th></tr>' +
             data.result +
             '</table>';
+          document.getElementById('exportBtn').style.display = 'none';
         }
 
         const payload = {
           action:
-            type === 'rate' ? 'RATE' : type === 'rewrite' ? 'REWRITE' : 'SUMMARY',
+            type === 'rate'
+              ? 'RATE'
+              : type === 'rewrite'
+              ? 'REWRITE'
+              : type === 'scripts'
+              ? 'SCRIPTS'
+              : 'SUMMARY',
           original_story: userStory,
           original_assumptions: assumptions,
           original_criteria: acceptanceCriteria,
@@ -311,6 +333,26 @@
         clearInterval(timerId);
         document.getElementById('timer').textContent = '0';
       }
+    }
+
+    function exportToCsv() {
+      const table = document.querySelector('#result table');
+      if (!table) return;
+      const rows = Array.from(table.querySelectorAll('tr'));
+      const csv = rows
+        .map(row =>
+          Array.from(row.querySelectorAll('th,td'))
+            .map(cell => '"' + cell.innerText.replace(/"/g, '""') + '"')
+            .join(',')
+        )
+        .join('\n');
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = 'test-scripts.csv';
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add new Generate Test Scripts button to the web UI
- send an advanced prompt to OpenAI and display the steps in a table
- export generated test scripts to Excel
- document the new feature in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6873d4da194c832cbf030b03d159e591