### PR TITLE
Use summary scenarios in test scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ The web UI offers four AI-powered actions:
 - **Generate Test Scripts** &ndash; produces detailed test scripts that can be exported to Excel.
   Use the "Generate Test Scripts" button to run an advanced prompt that returns
   step-by-step test cases in JSON format, automatically rendered as a table with
-  an option to export the results to Excel.
+  an option to export the results to Excel. This action relies on the scenarios
+  produced by the most recent **Test & Risk Summary**.
 
 ## API Endpoints
 

--- a/public/index.html
+++ b/public/index.html
@@ -198,6 +198,7 @@
     <button onclick="callOpenAI('rewrite')">Re-write</button>
     <button onclick="callOpenAI('summary')">Test &amp; Risk Summary</button>
     <button onclick="callOpenAI('scripts')" id="scriptsBtn">Generate Test Scripts</button>
+    <p style="font-size:0.9em;color:#555;margin:4px 0;">Test scripts rely on the most recent summary.</p>
     <button id="exportBtn" style="display:none;" onclick="exportToCsv()">Export to Excel</button>
     <div id="loader" style="display:none;" class="spinner"><span id="timer">0</span></div>
     <div id="result"></div>
@@ -209,8 +210,9 @@
       document.body.classList.add('theme-' + name);
     }
 
-    let timerId;
-    let startTime;
+      let timerId;
+      let startTime;
+      let summaryScenarios = [];
 
     document.addEventListener('DOMContentLoaded', () => {
       const selector = document.getElementById('themeSelector');
@@ -233,7 +235,10 @@
         const secs = Math.floor((Date.now() - startTime) / 1000);
         timer.textContent = secs.toString();
       }, 1000);
-      document.getElementById('result').innerHTML = '';
+        document.getElementById('result').innerHTML = '';
+        if (type === 'summary') {
+          summaryScenarios = [];
+        }
 
       const userStory = document.getElementById('userStory').value;
       const assumptions = document.getElementById('assumptions').value;
@@ -244,9 +249,33 @@
         prompt = `Please rate the following user story based on the following criteria:\n\n- Clarity\n- Feasibility\n- Testability\n- Completeness\n- Value\n\nReturn the results as HTML <tr> rows only, like this:\n<tr><td>Clarity</td><td>8/10</td><td>Clear but missing outcome detail</td></tr>\n...\n\nUser Story: ${userStory}\nAssumptions: ${assumptions}\nAcceptance Criteria: ${acceptanceCriteria}`;
       } else if (type === 'rewrite') {
         prompt = `Please rewrite the following user story in proper format.\n\n1. Use the format: 'As a [user], I want to [goal] so that [reason]'.\n2. List assumptions clearly.\n3. Provide well-defined, bullet-point acceptance criteria.\n4. Describe a brief test approach that covers the user story.\n\nUser Story: ${userStory}\nAssumptions: ${assumptions}\nAcceptance Criteria: ${acceptanceCriteria}`;
-      } else if (type === 'scripts') {
-        prompt = `You are a senior test analyst. Be extremely thorough and analytical.\n\nUse the following inputs provided by the user:\n\nUser Story:\n${userStory}\n\nAssumptions:\n${assumptions}\n\nAcceptance Criteria:\n${acceptanceCriteria}\n\nYour tasks:\n\n1. Carefully analyze this information and identify all possible test cases, including positive, negative, edge, and alternate scenarios that a senior QA would consider. Ensure no relevant scenario is missed.\n\n2. For each test case, generate all the detailed test steps needed to fully validate the scenario. Each test case must have its step numbering start at 1.\n\n3. Return the data as a structured JSON array of rows, where each row represents a single test step. Each row must include these exact fields:\n- id: leave this blank (Azure DevOps assigns it automatically)\n- work_item_type: always set to "Test Case"\n- title: the test case title (repeated on every row of that test case)\n- test_step: the step number, starting from 1 for each new test case\n- step_action: what the user does\n- step_expected: what is expected to happen\n\nImportant formatting requirements:\n- Each new test case must restart its test_step at 1.\n- Repeat the fields id, work_item_type, and title for every step of the same test case, as Azure DevOps needs this to group the steps under each test case.\n- Ensure every assumption and acceptance criterion is fully tested, and include any implied scenarios a professional senior QA would identify.\n\nOutput only the JSON array of rows, with no extra commentary or explanation. Format it cleanly for easy parsing.`;
       } else {
+        } else if (type === 'scripts') {
+          const scenarioText =
+            summaryScenarios.length > 0
+              ? `\nBased on these scenarios: ${summaryScenarios.join('; ')}\n`
+              : '';
+          prompt =
+            `You are a senior test analyst. Be extremely thorough and analytical.\n\n` +
+            `Use the following inputs provided by the user:\n\n` +
+            `User Story:\n${userStory}\n\n` +
+            `Assumptions:\n${assumptions}\n\n` +
+            `Acceptance Criteria:\n${acceptanceCriteria}${scenarioText}\n\n` +
+            `Your tasks:\n\n` +
+            `1. Carefully analyze this information and identify all possible test cases, including positive, negative, edge, and alternate scenarios that a senior QA would consider. Ensure no relevant scenario is missed.\n\n` +
+            `2. For each test case, generate all the detailed test steps needed to fully validate the scenario. Each test case must have its step numbering start at 1.\n\n` +
+            `3. Return the data as a structured JSON array of rows, where each row represents a single test step. Each row must include these exact fields:\n` +
+            `- id: leave this blank (Azure DevOps assigns it automatically)\n` +
+            `- work_item_type: always set to "Test Case"\n` +
+            `- title: the test case title (repeated on every row of that test case)\n` +
+            `- test_step: the step number, starting from 1 for each new test case\n` +
+            `- step_action: what the user does\n` +
+            `- step_expected: what is expected to happen\n\n` +
+            `Important formatting requirements:\n` +
+            `- Each new test case must restart its test_step at 1.\n` +
+            `- Repeat the fields id, work_item_type, and title for every step of the same test case, as Azure DevOps needs this to group the steps under each test case.\n` +
+            `- Ensure every assumption and acceptance criterion is fully tested, and include any implied scenarios a professional senior QA would identify.\n\n` +
+            `Output only the JSON array of rows, with no extra commentary or explanation. Format it cleanly for easy parsing.`;
         prompt = `Summarize recommended test cases for the following user story. Provide a table using the columns ID, Test Description and Risk Level. Return only HTML <tr> rows.\n\nUser Story: ${userStory}\nAssumptions: ${assumptions}\nAcceptance Criteria: ${acceptanceCriteria}`;
       }
 
@@ -282,11 +311,16 @@
           document.getElementById('result').innerHTML = html;
           document.getElementById('exportBtn').style.display = 'inline-block';
         } else {
-          document.getElementById('result').innerHTML =
-            '<table><tr><th>ID</th><th>Test Description</th><th>Risk Level</th></tr>' +
-            data.result +
-            '</table>';
-          document.getElementById('exportBtn').style.display = 'none';
+            document.getElementById('result').innerHTML =
+              '<table><tr><th>ID</th><th>Test Description</th><th>Risk Level</th></tr>' +
+              data.result +
+              '</table>';
+            const tmp = document.createElement('table');
+            tmp.innerHTML = data.result;
+            summaryScenarios = Array.from(tmp.querySelectorAll('tr'))
+              .map(r => r.children[1]?.innerText.trim())
+              .filter(Boolean);
+            document.getElementById('exportBtn').style.display = 'none';
         }
 
         const payload = {


### PR DESCRIPTION
## Summary
- store summary scenarios in the front-end
- include those scenarios in the test script prompt
- reset scenarios when a new summary is generated
- show a UI hint and document the dependency

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6873e4468990832ca2d57ebc549a8d77