### PR TITLE
Remove Generate Test Scripts button

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,21 +20,17 @@ Set a few environment variables before starting the server:
 Add these variables to a `.env` file or export them in your shell, then start
 the server with `npm start`.
 
-The web UI offers four AI-powered actions:
+The web UI offers three AI-powered actions:
 
 - **Rate It** &ndash; scores the user story against multiple criteria.
 - **Re-write** &ndash; rewrites the story, lists assumptions and acceptance
   criteria, and now includes a short test approach tailored to the story.
 - **Test & Risk Summary** &ndash; generates a concise table of suggested test cases.
-- **Generate Test Scripts** &ndash; generates detailed test scripts for the scenarios listed in **Test & Risk Summary** and can export the results to Excel.
-  Use the "Generate Test Scripts" button after creating a summary to produce
-  step-by-step test cases in JSON format, automatically rendered as a table with
-  an option to export to Excel.
 
 ## API Endpoints
 
 - `POST /user-story` - Persist a user story and associated AI data. The payload
-  varies based on the `action` (`RATE`, `REWRITE`, `SUMMARY` or `SCRIPTS`) and always includes
+  varies based on the `action` (`RATE`, `REWRITE`, `SUMMARY`) and always includes
   `raw_response` from ChatGPT.
 - `GET /health` - Database connectivity check. Returns `200` when the database
   is reachable.

--- a/devops-extension/index.html
+++ b/devops-extension/index.html
@@ -10,8 +10,6 @@
     <button id="rateBtn">Rate It</button>
     <button id="rewriteBtn">Re-write</button>
     <button id="summaryBtn">Test &amp; Risk Summary</button>
-    <button id="scriptsBtn">Generate Test Scripts</button>
-    <button id="exportBtn" style="display:none;">Export to CSV</button>
     <div id="loader" style="display:none;">Loading...</div>
     <pre id="result"></pre>
   </div>

--- a/devops-extension/index.js
+++ b/devops-extension/index.js
@@ -11,12 +11,6 @@ SDK.ready().then(function() {
   document.getElementById("summaryBtn").addEventListener("click", function() {
     handleAction("summary");
   });
-  document.getElementById("scriptsBtn").addEventListener("click", function() {
-    handleAction("scripts");
-  });
-  document.getElementById("exportBtn").addEventListener("click", function() {
-    exportToCsv();
-  });
 });
 
 async function handleAction(type) {
@@ -30,8 +24,6 @@ async function handleAction(type) {
     prompt = `Please rate the following user story based on clarity, feasibility, testability, completeness and value. Return HTML <tr> rows only.\nTitle: ${title}\nDescription: ${description}`;
   } else if (type === "rewrite") {
     prompt = `Please rewrite the user story and provide a short test approach that matches it.\nTitle: ${title}\nDescription: ${description}`;
-  } else if (type === "scripts") {
-    prompt = `Analyze the user story and identify all test scenarios including positive, negative and edge cases. For each scenario, provide at least three numbered steps with the action and expected result. Use a table with columns Scenario Title, Action and Expected Result, repeating the scenario title for every step. Return only HTML <tr> rows.\nTitle: ${title}\nDescription: ${description}`;
   } else {
     prompt = `Summarize recommended test cases in a table with columns ID, Test Description and Risk Level. Return only HTML <tr> rows.\nTitle: ${title}\nDescription: ${description}`;
   }
@@ -47,36 +39,9 @@ async function handleAction(type) {
     }
     var data = await response.json();
     document.getElementById("result").innerHTML = data.result;
-    if (type === "scripts") {
-      document.getElementById("exportBtn").style.display = "block";
-    } else {
-      document.getElementById("exportBtn").style.display = "none";
-    }
   } catch (err) {
     document.getElementById("result").textContent = "Error: " + err.message;
   } finally {
     document.getElementById("loader").style.display = "none";
   }
-}
-
-function exportToCsv() {
-  var table = document.querySelector("#result table");
-  if (!table) return;
-  var rows = Array.from(table.querySelectorAll("tr"));
-  var csv = rows
-    .map(function(row) {
-      return Array.from(row.querySelectorAll("th,td"))
-        .map(function(cell) {
-          return '"' + cell.innerText.replace(/"/g, '""') + '"';
-        })
-        .join(",");
-    })
-    .join("\n");
-  var blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
-  var link = document.createElement("a");
-  link.href = URL.createObjectURL(blob);
-  link.download = "test-scripts.csv";
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
 }


### PR DESCRIPTION
## Summary
- remove Generate Test Scripts and export buttons from the Azure DevOps extension
- drop related script generation and export logic
- document only the remaining three UI actions

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_688bb87df854832cb6fc5e91fb4be9d6